### PR TITLE
connectDB.ts 함수 client 변수 타입 수정 any -> MongoClient | null & MONGO_URI…

### DIFF
--- a/src/app/lib/connectDB.ts
+++ b/src/app/lib/connectDB.ts
@@ -1,15 +1,17 @@
 import { MongoClient } from "mongodb";
 
-let client: any = null;
+let client: MongoClient | null = null;
+// 타입 단언 사용 : TypeScript 에서는 타입 단언을 사용하여, 변수의 타입을 지정할 수 있습니다.
+const MONGO_URI = process.env.MONGO_URI as string;
 
 async function connectDB() {
   if (client) {
-    // 이미 연결된 경우
+    // 이미 연결된 경우 재사용 및 함수 종료
     return client;
   }
 
   try {
-    client = new MongoClient(process.env.MONGO_URI || "");
+    client = new MongoClient(MONGO_URI);
     await client.connect();
   } catch (error) {
     console.error("MongoDB 연결에 실패했습니다:", error);


### PR DESCRIPTION
coonectDB.ts 함수 에서   
client 변수 타입을 수정하였습니다.

```javascript
let client: MongoClient | null = null;

```

환경변수 MONGO_URI 변수를 선언하여, 타입 단언을 사용하여, 변수의 타입을 지정해주었습니다.

```javascript
// 타입 단언 사용 : TypeScript 에서는 타입 단언을 사용하여, 변수의 타입을 지정할 수 있습니다.
const MONGO_URI = process.env.MONGO_URI as string;
```